### PR TITLE
Remove peerDependency on old grunt version

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,9 +34,6 @@
     "grunt-contrib-nodeunit": "~0.2.0",
     "grunt": "~0.4.2"
   },
-  "peerDependencies": {
-    "grunt": "~0.4.2"
-  },
   "dependencies": {
     "async": "~0.2.9"
   },


### PR DESCRIPTION
It causes warning during install, and shouldn't be necessary: Ref https://github.com/gruntjs/grunt/issues/1537#issuecomment-235324836